### PR TITLE
feat: add Muted account state with auto-recovery and countdown UI

### DIFF
--- a/src/ds_core/accounts.rs
+++ b/src/ds_core/accounts.rs
@@ -23,6 +23,7 @@ pub enum AccountState {
     Busy = 1,
     Error = 2,
     Invalid = 3,
+    Muted = 4,
 }
 
 impl AccountState {
@@ -31,16 +32,19 @@ impl AccountState {
             0 => Self::Idle,
             1 => Self::Busy,
             2 => Self::Error,
+            3 => Self::Invalid,
+            4 => Self::Muted,
             _ => Self::Invalid,
         }
     }
 
-    fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Idle => "idle",
             Self::Busy => "busy",
             Self::Error => "error",
             Self::Invalid => "invalid",
+            Self::Muted => "muted",
         }
     }
 }
@@ -55,6 +59,8 @@ pub struct AccountStatus {
     pub last_released_ms: i64,
     /// 连续登录失败次数
     pub error_count: u8,
+    /// 禁言截止时间戳（秒），仅当 state == "muted" 时有意义
+    pub mute_until: i64,
 }
 
 pub struct Account {
@@ -68,6 +74,8 @@ pub struct Account {
     error_count: AtomicU8,
     /// 原始凭据（用于重新登录）
     creds: AccountConfig,
+    /// 禁言截止时间戳（秒），0 表示未禁言
+    mute_until: AtomicI64,
 }
 
 /// 连续登录失败上限，达到后标记为 Invalid
@@ -95,7 +103,41 @@ impl Account {
     }
 
     pub fn is_available(&self) -> bool {
-        self.state() == AccountState::Idle
+        loop {
+            let state = self.state();
+            if state != AccountState::Muted {
+                return state == AccountState::Idle;
+            }
+
+            let now = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64;
+            let until = self.mute_until.load(Ordering::Relaxed);
+            if until <= 0 || now < until {
+                return false;
+            }
+
+            // CAS: 只有当前仍是 Muted 时才恢复为 Idle
+            match self.state.compare_exchange(
+                AccountState::Muted as u8,
+                AccountState::Idle as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    self.mute_until.store(0, Ordering::Relaxed);
+                    self.error_count.store(0, Ordering::Relaxed);
+                    info!(target: "ds_core::accounts", "账号 {} 禁言到期，自动恢复为 Idle", self.display_id());
+                    return true;
+                }
+                Err(_) => continue,
+            }
+        }
+    }
+
+    pub fn mute_until(&self) -> i64 {
+        self.mute_until.load(Ordering::Relaxed)
     }
 
     /// 创建一个 Invalid 状态的账号（初始化失败时使用，仍加入池以便前台展示）
@@ -108,6 +150,7 @@ impl Account {
             last_released: AtomicI64::new(0),
             error_count: AtomicU8::new(MAX_ERROR_COUNT),
             creds,
+            mute_until: AtomicI64::new(0),
         }
     }
 }
@@ -290,7 +333,7 @@ impl AccountPool {
             return Err(PoolError::AccountBusy(email_or_mobile.to_string()));
         }
 
-        // 也允许移除 Error/Invalid 状态的账号
+        // 也允许移除 Error/Invalid/Muted 状态的账号
         drop(account);
         let (_, removed) = self
             .accounts
@@ -369,6 +412,7 @@ impl AccountPool {
                     state: a.state().as_str().to_string(),
                     last_released_ms: a.last_released.load(Ordering::Relaxed),
                     error_count: a.error_count.load(Ordering::Relaxed),
+                    mute_until: a.mute_until(),
                 }
             })
             .collect()
@@ -387,7 +431,7 @@ impl AccountPool {
     pub fn mark_error(&self, email_or_mobile: &str) {
         if let Some(entry) = self.accounts.get(email_or_mobile) {
             let account = entry.value();
-            // 只从 Busy 转到 Error（避免覆盖 Invalid）
+            // 只从 Busy 转到 Error（避免覆盖 Invalid/Muted）
             account
                 .state
                 .compare_exchange(
@@ -398,6 +442,43 @@ impl AccountPool {
                 )
                 .ok();
             warn!(target: "ds_core::accounts", "账号 {} 标记为 Error", account.display_id());
+        }
+    }
+
+    /// 标记账号为 Muted 状态（临时封禁）
+    pub fn mark_muted(&self, email_or_mobile: &str, mute_until: i64) {
+        if let Some(entry) = self.accounts.get(email_or_mobile) {
+            let account = entry.value();
+            // 从 Busy 或 Idle 转到 Muted（Idle 表示请求已结束但响应延迟到达）
+            let _ = account
+                .state
+                .compare_exchange(
+                    AccountState::Busy as u8,
+                    AccountState::Muted as u8,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                );
+            let _ = account
+                .state
+                .compare_exchange(
+                    AccountState::Idle as u8,
+                    AccountState::Muted as u8,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                );
+            account.mute_until.store(mute_until, Ordering::Relaxed);
+            warn!(
+                target: "ds_core::accounts",
+                "账号 {} 标记为 Muted，解封时间: {}",
+                account.display_id(),
+                if mute_until == 0 {
+                    "永久".to_string()
+                } else {
+                    chrono::DateTime::from_timestamp(mute_until, 0)
+                        .map(|dt| dt.to_string())
+                        .unwrap_or_else(|| mute_until.to_string())
+                }
+            );
         }
     }
 
@@ -416,7 +497,7 @@ impl AccountPool {
             .ok_or_else(|| format!("账号 {} 不存在", email_or_mobile))?;
         let account = account.value();
 
-        // 只允许 Error/Invalid 状态的账号重登
+        // 只允许 Error/Invalid 状态的账号重登（Muted 需要等待解封或手动处理）
         let state = account.state();
         if state != AccountState::Error && state != AccountState::Invalid {
             return Err(format!(
@@ -564,6 +645,7 @@ async fn try_init_account(
         last_released: AtomicI64::new(0),
         error_count: AtomicU8::new(0),
         creds: creds.clone(),
+        mute_until: AtomicI64::new(0),
     })
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -111,6 +111,7 @@ export interface AccountStatus {
   state: string;
   last_released_ms: number;
   error_count: number;
+  mute_until: number;
 }
 
 export interface AdminStatusResponse {
@@ -120,6 +121,7 @@ export interface AdminStatusResponse {
   busy: number;
   error: number;
   invalid: number;
+  muted: number;
 }
 
 export interface StatsSnapshot {

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -51,7 +51,8 @@
       "idle": "Idle",
       "busy": "Busy",
       "error": "Error",
-      "invalid": "Invalid"
+      "invalid": "Invalid",
+      "muted": "Muted"
     }
   },
   "config": {

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -51,7 +51,8 @@
       "idle": "空闲",
       "busy": "忙碌",
       "error": "异常",
-      "invalid": "失效"
+      "invalid": "失效",
+      "muted": "禁言"
     }
   },
   "config": {

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -227,23 +227,53 @@ export function DashboardPage() {
               <div className="text-3xl font-bold text-red-600">{status?.invalid ?? '-'}</div>
               <div className="text-sm text-muted-foreground">{t('dashboard.accountPool.invalid')}</div>
             </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-purple-600">{status?.muted ?? '-'}</div>
+              <div className="text-sm text-muted-foreground">{t('dashboard.accountPool.muted')}</div>
+            </div>
           </div>
           <div className="mt-4 flex flex-wrap gap-2">
             {status?.accounts.map((a) => {
               const isBusy = a.state === 'busy';
               const isError = a.state === 'error';
               const isInvalid = a.state === 'invalid';
-              const variant = isBusy ? 'default' : isError ? 'secondary' : isInvalid ? 'destructive' : 'secondary';
-              const className = isBusy
-                ? 'bg-amber-500/15 text-amber-700 border-amber-200'
-                : isError
-                ? 'bg-yellow-500/15 text-yellow-700 border-yellow-200'
-                : isInvalid
-                ? 'bg-red-500/15 text-red-700 border-red-200'
-                : 'bg-green-500/15 text-green-700 border-green-200';
+              const isMuted = a.state === 'muted';
+              let variant = 'secondary';
+              let className = 'bg-green-500/15 text-green-700 border-green-200';
+              let displayText = a.email || a.mobile;
+
+              if (isBusy) {
+                variant = 'default';
+                className = 'bg-amber-500/15 text-amber-700 border-amber-200';
+              } else if (isError) {
+                variant = 'secondary';
+                className = 'bg-yellow-500/15 text-yellow-700 border-yellow-200';
+              } else if (isInvalid) {
+                variant = 'destructive';
+                className = 'bg-red-500/15 text-red-700 border-red-200';
+              } else if (isMuted) {
+                variant = 'secondary';
+                className = 'bg-purple-500/15 text-purple-700 border-purple-200';
+                // 显示解封倒计时
+                if (a.mute_until && a.mute_until > 0) {
+                  const now = Date.now() / 1000;
+                  const remainingSecs = Math.max(0, a.mute_until - now);
+                  if (remainingSecs > 0) {
+                    const hours = Math.floor(remainingSecs / 3600);
+                    const minutes = Math.floor((remainingSecs % 3600) / 60);
+                    const seconds = Math.floor(remainingSecs % 60);
+                    let remainingStr = '';
+                    if (hours > 0) remainingStr = `${hours}h ${minutes}m`;
+                    else if (minutes > 0) remainingStr = `${minutes}m ${seconds}s`;
+                    else remainingStr = `${seconds}s`;
+                    displayText = `${a.email || a.mobile} (${remainingStr})`;
+                  }
+                }
+              }
+
               return (
                 <Badge key={a.email || a.mobile} variant={variant} className={className}>
-                  {a.email || a.mobile}
+                  {displayText}
                 </Badge>
               );
             })}


### PR DESCRIPTION
## Summary
- 新增 `Muted` 账号状态，支持临时封禁与永久禁言
- `is_available()` 检测封禁到期后 CAS 自动恢复为 Idle
- `mark_muted()` 覆盖 Busy 和 Idle 两种前状态
- 前端仪表盘展示 Muted 计数、紫色徽章、解封倒计时

## Test plan
- [ ] 编译通过 (`cargo check`)
- [ ] 禁言到期自动恢复为 Idle
- [ ] 仪表盘正确显示 Muted 状态和倒计时
- [ ] `invalid` 和 `muted` 翻译共存

🤖 Generated with [Claude Code](https://claude.com/claude-code)